### PR TITLE
Add custom locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Whatsapp Web is constantly changing so this library is very susceptible to break
 
 - [Objects](#objects)
 
+- [Locators](#locators)
+
 - [To Do List](#to-do-list)
 
 ## Installation
@@ -168,6 +170,14 @@ Class `redshot.object.SearchResult`:
 - `info`: The search result's info section
 - `unread_messages`: The number of unread messages
 - `group`: The group the search result is in (if the search result is a chat)
+
+## Locators
+
+In the likely event that Whatsapp changes the structure of their website, issues may be fixed in the short term by manually overloading certain locators. Each locator is a tuple pair (by, by_str) which allow you to find elements in HTML by a certain characteristic (e.g. name, xpath, id, etc). 
+
+`redshot.constants.Locator.set_locator(locator_name, locator)`: Updates a single locator (see the source code for the given locator name). Returns `True` if successful.
+
+`redshot.constants.Locator.set_locator(locators)`: Updates multiple locators by passing a `dict` of locator names and associated tuples. Returns a list of booleans.
 
 ## To Do List
 

--- a/redshot/constants/locator.py
+++ b/redshot/constants/locator.py
@@ -1,3 +1,4 @@
+from typing import List
 from selenium.webdriver.common.by import By
 
 class Locator:
@@ -38,3 +39,44 @@ class Locator:
     CHAT_MESSAGE_QUOTE = (By.XPATH, ".//div[@aria-label='Quoted message']")
     CHAT_MESSAGE_IMAGE = (By.XPATH, ".//div[@aria-label='Open picture']")
     CHAT_MESSAGE_IMAGE_ELEMENT = (By.XPATH, ".//img[starts-with(@src, 'blob:https://web.whatsapp.com')]")
+
+    @classmethod
+    def set_locator(cls, locator_name: str, locator: tuple) -> bool:
+        """
+        Sets a specific locator to a new value.
+
+        Parameters:
+            locator_name (str): The name of the locator you want to update.
+            locator (tuple): The new locator tuple (e.g., (By.ID, "new_id_value")).
+        """
+        name = locator_name.upper()
+
+        if hasattr(cls, name):
+            setattr(cls, name, locator)
+            return True
+        
+        return False
+
+    @classmethod
+    def set_locators(cls, locators: dict) -> List[bool]:
+        """
+        Bulk-updates multiple locators.
+
+        Parameters:
+            locators (dict): A dictionary where keys are locator names (str) and values are the new locator tuples.
+        """
+        return [cls.set_locator(key, value) for key, value in locators.items()]
+        
+    @classmethod
+    def get_locator(cls, locator_name: str):
+        """
+        Retrieves a locator tuple by name.
+
+        Parameters:
+            locator_name (str): The name of the locator.
+
+        Returns:
+            tuple: The locator tuple if found, else None.
+        """
+        return getattr(cls, locator_name.upper(), None)
+    


### PR DESCRIPTION
Adds `redshot.constants.Locator.set_locator` and `redshot.constants.Locator.set_locators` methods to allow users to customise their locators in the case that Whatsapp's website structure changes.